### PR TITLE
Fixed Wizard Displaying App Title at Top

### DIFF
--- a/app/src/main/java/yeet/dungeonsomething/dungeoncharactercreator/Views/WizardTabsActivity.java
+++ b/app/src/main/java/yeet/dungeonsomething/dungeoncharactercreator/Views/WizardTabsActivity.java
@@ -29,6 +29,8 @@ public class WizardTabsActivity extends AppCompatActivity {
         //Get toolbar from activity_wizard_tabs
         Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
+        getSupportActionBar().setDisplayShowTitleEnabled(false);
+        toolbar.setTitle("");
         //Get the tablayout -- Define tab text...
         TabLayout layout = (TabLayout) findViewById(R.id.tab_layout);
         //Making the tabs scrollable so text can all be seen -- probably not necessary for character sheet part


### PR DESCRIPTION
Wizard was displaying the title of the app above the navigation tabs at the top of the activity. That's gone now.